### PR TITLE
Rename export sesison to fix symbols error

### DIFF
--- a/ios/RNPhotosFramework/PHVideoExporter.h
+++ b/ios/RNPhotosFramework/PHVideoExporter.h
@@ -9,5 +9,5 @@ typedef void (^videoExporterProgressBlock)(float progress);
 -(void (^_Nonnull)()) exportVideoWithAsset:(AVAsset *_Nonnull)avasset andDir:(NSString *_Nonnull)dir andFileName:(NSString *_Nonnull)fileName andPostProcessParams:(NSDictionary *_Nullable)params andProgressBlock:(videoExporterProgressBlock _Nonnull )progressBlock andCompletionBlock:(videoExporterCompleteBlock _Nonnull )completeBlock;
 
 @property (nonatomic, copy) videoExporterProgressBlock _Nonnull progressBlock;
-@property (strong, nonatomic) SDAVAssetExportSession * _Nullable encoder;
+@property (strong, nonatomic) RNPhotosSDAVAssetExportSession * _Nullable encoder;
 @end

--- a/ios/RNPhotosFramework/PHVideoExporter.m
+++ b/ios/RNPhotosFramework/PHVideoExporter.m
@@ -59,7 +59,7 @@
         }
     }
 
-    self.encoder = [SDAVAssetExportSession.alloc initWithAsset:avasset];
+    self.encoder = [RNPhotosSDAVAssetExportSession.alloc initWithAsset:avasset];
     
     [_encoder addObserver:self forKeyPath:@"progress" options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:nil];
     

--- a/ios/RNPhotosFramework/PhotosSDAVAssetExportSession.h
+++ b/ios/RNPhotosFramework/PhotosSDAVAssetExportSession.h
@@ -1,5 +1,5 @@
 //
-//  SDAVAssetExportSession.h
+//  RNPhotosSDAVAssetExportSession.h
 //
 // This file is part of the SDAVAssetExportSession package.
 //
@@ -13,7 +13,7 @@
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
 
-@protocol SDAVAssetExportSessionDelegate;
+@protocol RNPhotosSDAVAssetExportSessionDelegate;
 
 
 /**
@@ -33,9 +33,9 @@
  * about the reason for the failure.
  */
 
-@interface SDAVAssetExportSession : NSObject
+@interface RNPhotosSDAVAssetExportSession : NSObject
 
-@property (nonatomic, weak) id<SDAVAssetExportSessionDelegate> delegate;
+@property (nonatomic, weak) id<RNPhotosSDAVAssetExportSessionDelegate> delegate;
 
 /**
  * The asset with which the export session was initialized.
@@ -187,8 +187,8 @@
 @end
 
 
-@protocol SDAVAssetExportSessionDelegate <NSObject>
+@protocol RNPhotosSDAVAssetExportSessionDelegate <NSObject>
 
-- (void)exportSession:(SDAVAssetExportSession *)exportSession renderFrame:(CVPixelBufferRef)pixelBuffer withPresentationTime:(CMTime)presentationTime toBuffer:(CVPixelBufferRef)renderBuffer;
+- (void)exportSession:(RNPhotosSDAVAssetExportSession *)exportSession renderFrame:(CVPixelBufferRef)pixelBuffer withPresentationTime:(CMTime)presentationTime toBuffer:(CVPixelBufferRef)renderBuffer;
 
 @end

--- a/ios/RNPhotosFramework/PhotosSDAVAssetExportSession.m
+++ b/ios/RNPhotosFramework/PhotosSDAVAssetExportSession.m
@@ -1,5 +1,5 @@
 //
-//  SDAVAssetExportSession.m
+//  RNPhotosSDAVAssetExportSession.m
 //
 // This file is part of the SDAVAssetExportSession package.
 //
@@ -13,7 +13,7 @@
 
 #import "SDAVAssetExportSession.h"
 
-@interface SDAVAssetExportSession ()
+@interface RNPhotosSDAVAssetExportSession ()
 
 @property (nonatomic, assign, readwrite) float progress;
 
@@ -29,7 +29,7 @@
 
 @end
 
-@implementation SDAVAssetExportSession
+@implementation RNPhotosSDAVAssetExportSession
 {
     NSError *_error;
     NSTimeInterval duration;
@@ -38,7 +38,7 @@
 
 + (id)exportSessionWithAsset:(AVAsset *)asset
 {
-    return [SDAVAssetExportSession.alloc initWithAsset:asset];
+    return [RNPhotosSDAVAssetExportSession.alloc initWithAsset:asset];
 }
 
 - (id)initWithAsset:(AVAsset *)asset


### PR DESCRIPTION
I don't know how to fix a duplicate symbols error so I renamed the class.