### PR TITLE
Use unique identifier for live photos

### DIFF
--- a/ios/RNPhotosFramework/RNPFManager.m
+++ b/ios/RNPhotosFramework/RNPFManager.m
@@ -506,7 +506,7 @@ RCT_EXPORT_METHOD(saveLivePhotoToDisk:(NSString *)localIdentifier
             return resolve([NSNull null]);
         }
         
-        NSString* identifier = [localIdentifier componentsSeparatedByString:@"/"][0];
+        NSString* identifier = [NSString stringWithFormat:@"%@", [localIdentifier stringByReplacingOccurrencesOfString:@"/" withString:@""]];
         NSString* filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"live_%@.%@", identifier, [videoResource.originalFilename pathExtension]]];
         NSURL *fileUrl = [NSURL fileURLWithPath:filePath];
         

--- a/ios/RNPhotosFramework/RNPFManager.m
+++ b/ios/RNPhotosFramework/RNPFManager.m
@@ -506,7 +506,8 @@ RCT_EXPORT_METHOD(saveLivePhotoToDisk:(NSString *)localIdentifier
             return resolve([NSNull null]);
         }
         
-        NSString* filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:videoResource.originalFilename];
+        NSString* identifier = [localIdentifier componentsSeparatedByString:@"/"][0];
+        NSString* filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"live_%@.%@", identifier, [videoResource.originalFilename pathExtension]]];
         NSURL *fileUrl = [NSURL fileURLWithPath:filePath];
         
         if ([[NSFileManager defaultManager] fileExistsAtPath:filePath]) {


### PR DESCRIPTION
Solves https://app.asana.com/0/1147613925159257/1161771723475806

Seems like originalFilename is not always unique, which causes a mismatch when we check if an exported live photo already exists in our temporary storage (for performance). Was able to reproduce this scenario artificially by editing files in temp storage. 

Each exported live photo will now get a name based on the system unique identifier so the mapping is always correct. Seems like for normal videos we already did this.