### PR TITLE
Add correct podspec file name

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "README.md",
     "install.js",
     "event-emitter.js",
-    "react-native-photos-framework.podspec"
+    "RNPhotosFramework.podspec"
   ],
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
So we can install this package with `npm i relivecc/react-native-photos-framework` and pods can be installed.