### PR TITLE
Don't pass nil as album type

### DIFF
--- a/ios/RNPhotosFramework/PHCollectionService.m
+++ b/ios/RNPhotosFramework/PHCollectionService.m
@@ -138,7 +138,7 @@ static id ObjectOrNull(id object)
         PHAssetCollection *phAssetCollection = (PHAssetCollection *)collection;
         PHAssetCollectionType albumType = [phAssetCollection assetCollectionType];
         PHAssetCollectionSubtype subType = [phAssetCollection assetCollectionSubtype];
-        [albumDictionary setObject:[[RCTConvert PHAssetCollectionTypeValuesReversed] objectForKey:@(albumType)] forKey:@"type"];
+        [albumDictionary setObject:ObjectOrNull([[RCTConvert PHAssetCollectionTypeValuesReversed] objectForKey:@(albumType)]) forKey:@"type"];
         if(subType == 1000000201) {
             //Some kind of undocumented value here for recentlyDeleted
             //Found references to this when i Googled.


### PR DESCRIPTION

## What type of PR is this? (Check all if applicable)

- [ ] Feature
- [x] Bug fix
- [ ] Refactor

## Description

User complained that the app crashes in the photo select modal. I noticed that the type/album type can be `nil`. Managed to reproduce it by passing `nil` in line 141. To solve this issue `objectOrNull()` Added to handle the `nil`. 

Having `null` is tested and won't cause any issue. 



## [optional] What GIF best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/hPTZgtzfRIB5Nfb5rL/giphy-downsized.gif)
